### PR TITLE
feat: Increase max-lines-per-function limit, skip blanks and comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -273,7 +273,15 @@ module.exports = {
         ignoreTemplateLiterals: true,
       }
     ],
-    "max-lines-per-function": ["error", 15],
+    "max-lines-per-function": [
+      "error",
+      {
+        max: 20,
+        skipBlankLines: true,
+        skipComments: true,
+        IIFEs: true
+      },
+    ],
     "max-params": ["error", 7],
     "max-statements-per-line": [
       "error",


### PR DESCRIPTION
Update `max-lines-per-function` rule options.