### PR TITLE
fix(stylistic/max-len): make ignorePattern actually match export/import

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,7 +213,7 @@ export default defineConfig([
       "max-params": ["error", 7],
       "@stylistic/max-len": [
         "error",
-        { code: 120, ignoreComments: true, ignorePattern: "^(export|import)*", ignoreTemplateLiterals: true },
+        { code: 120, ignoreComments: true, ignorePattern: "^(export|import)\\b", ignoreTemplateLiterals: true },
       ],
       "@stylistic/max-statements-per-line": ["error", { max: 1 }],
       "@stylistic/spaced-comment": "error",


### PR DESCRIPTION
## Summary

Stacked on top of [#51](https://github.com/deepcrawl/eslint-config/pull/51).

`@stylistic/max-len`'s `ignorePattern` had the regex `^(export|import)*` — the trailing `*` quantifier matches **zero or more** occurrences, so the pattern matches the empty string at the start of every line and exempts every line from `max-len`. That regex has been in the config since well before v15 and silently disabled `max-len` the whole time.

Replace with `^(export|import)\b` so only lines that actually begin with `export` or `import` are exempt.

## Verification

```ts
// 154 chars, not export/import — now reports @stylistic/max-len ✓
const reallyLongIdentifierName = "aaa…aaa";
// 120+ chars, exempt ✓
export const longExportLine = "aaa…aaa";
// 120+ chars, exempt ✓
import type * as LongImport from "aaa…aaa";
```

## Breaking change

Long lines (>120 chars) that were previously masked by the broken pattern will now report `@stylistic/max-len` errors. Consumers (canary etc.) may need to:

- shorten the offending lines (preferred),
- `// eslint-disable-next-line @stylistic/max-len` per-line,
- override `@stylistic/max-len` options per-file or globally.

I'd recommend merging #51 first (v15.0.0) and merging this as a follow-up minor/major depending on how risky the consumer impact is.

## Test plan

- [x] Smoke tested: non-export long lines now fail, export/import lines remain exempt.
- [x] `yarn prettier:check` passes.